### PR TITLE
docs: fix rendering of endpoint listing

### DIFF
--- a/docs/learn/threads/files/mills.md
+++ b/docs/learn/threads/files/mills.md
@@ -29,6 +29,7 @@ type Result struct {
 ## Endpoints
 
 Currently, Textile supports five Mill 'endpoints' or methods:
+
 * `blob`: Takes a binary data blob, and optionally encrypts it, before adding to IPFS,
 and returns a file object
 * `schema`: Takes a JSON-based Schema, validates it, adds it to IPFS, and returns a file object


### PR DESCRIPTION
Currently is being rendered like so:

![Screen Shot 2019-04-18 at 1 14 36 pm](https://user-images.githubusercontent.com/61148/56334519-fead1980-61db-11e9-92f2-ea8def19466e.png)
