### PR TITLE
Fix command keywords in a-tour-of-textile.md

### DIFF
--- a/docs/a-tour-of-textile.md
+++ b/docs/a-tour-of-textile.md
@@ -107,7 +107,7 @@ As mentioned above, all peers have a special private _account_ thread. In additi
 Take a look at your account.
 
 ```tab="cmd"
-textile account get
+textile account contact
 ```
 
 ???+ success
@@ -176,7 +176,7 @@ In addition to your "self" contact, you can search for and add contacts to your 
 Try searching for "Andrew".
 
 ```tab="cmd"
-textile contacts search --name="Andrew"
+textile contacts search --username="Andrew"
 ```
 
 ??? success

--- a/docs/a-tour-of-textile.md
+++ b/docs/a-tour-of-textile.md
@@ -53,7 +53,7 @@ Addresses always start with a "P" for "public". Account _seeds_ (private keys) a
 You can set a display name for your peer. Interacting with other users is a lot easier with display names. However, they are _not_ unique on the network.
 
 ```tab="cmd"
-textile profile set name "Clyde"
+textile profile set username "Clyde"
 ```
 
 ??? success


### PR DESCRIPTION
Hi,
When trying out the latest version of textile `go-textile_v0.1.11_darwin-amd64.tar.gz`, I noticed that the following commands keywords not valid (in docs): 

1.  `textile profile set name <name>` ,  should be `textile profile set username`.
2. `textile account get`, should be `textile account contact`. 

Please review. Thanks.