### PR TITLE
Validate all js-client snippets + adds missing ones

### DIFF
--- a/docs/a-tour-of-textile.md
+++ b/docs/a-tour-of-textile.md
@@ -77,7 +77,8 @@ Now, with Textile ready, take a look at your peer profile:
 - `id`: Your embedded IPFS node's peer ID, which is unique on the network
 - `address`: Your wallet account's address (public key), which can be shared with other account peers
 
-Addresses always start with a "P" for "public". Account _seeds_ (private keys) always start with an "S" for "secret", which should help you remember which one to keep secret.
+!!! hint
+    Addresses always start with a "P" for "public". Account _seeds_ (private keys) always start with an "S" for "secret", which should help you remember which one to keep secret.
 
 !!! info
     Textile uses an [ed25519](https://ed25519.cr.yp.to/) [HD wallet](https://en.bitcoinwiki.org/wiki/Deterministic_wallet) and IPFS peer IDs because they provide fast key generation, signing, and verification. These properties become important on less powerful devices like phones.
@@ -2265,7 +2266,11 @@ When your peer starts, it loads a JSON [config file](/the-config-file) from the 
 We can view the entire config or a specific value behind any JSON key. Try viewing the "Addresses" config:
 
 ```tab="cmd"
-textile config "Addresses"
+{{core.config.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{core.config.js_http_client.code}}
 ```
 
 ???+ success
@@ -2284,7 +2289,11 @@ textile config "Addresses"
 Changing values follows the same pattern. We can update our second peer's gateway bind address as follows:
 
 ```tab="cmd"
-textile config "Addresses.Gateway" \"127.0.0.1:9090\"
+{{core.config_set.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{core.config_set.js_http_client.code}}
 ```
 
 ???+ success
@@ -2315,6 +2324,10 @@ You should now see the new gateway bind address in the config:
 
 ```tab="cmd"
 textile config
+```
+
+```JavaScript tab="JS HTTP"
+const config = await textile.config.get()
 ```
 
 ??? success
@@ -2429,7 +2442,11 @@ In order for clients to register with your cafe, they'll need one of its _client
 Create a token as follows:
 
 ```tab="cmd"
-textile tokens create
+{{cafes.tokens_create.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{cafes.tokens_create.js_http_client.code}}
 ```
 
 ???+ success
@@ -2442,7 +2459,11 @@ textile tokens create
 View the cafe's client tokens with the `ls` command:
 
 ```tab="cmd"
-textile tokens ls
+{{cafes.tokens_list.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{cafes.tokens_list.js_http_client.code}}
 ```
 
 ???+ success
@@ -2466,7 +2487,11 @@ Cafes perform work for their _clients_, which are account peers. Account peers d
 Using the token created above, register with your locally running test cafe:
 
 ```tab="cmd"
-textile cafes add "http://127.0.0.1:40601" --token="bYJLFjHsRsZjdzEwC2pJwQthmfYb3DPYyBCcU49Dkfqd5xGHk5NR77X8GDKG"
+{{cafes.add.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{cafes.add.js_http_client.code}}
 ```
 
 ???+ success
@@ -2500,7 +2525,11 @@ A new client account associated with the provided token was added to your cafe. 
 You can view your active cafe sessions with the `ls` command:
 
 ```tab="cmd"
-textile cafes ls
+{{cafes.list.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{cafes.list.js_http_client.code}}
 ```
 
 ??? success
@@ -2530,7 +2559,11 @@ textile cafes ls
 An account peer will periodically check each of its registered cafes for new messages received by the cafe on its behalf. You can also manually check for messages:
 
 ```tab="cmd"
-textile cafes messages
+{{cafes.messages.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{cafes.messages.js_http_client.code}}
 ```
 
 ???+ success
@@ -2545,7 +2578,11 @@ Messages are downloaded in batches and queued for processing.
 You can leave a cafe at any time. Data associated with your client account will be removed.
 
 ```tab="cmd"
-textile cafes rm "12D3KooW9yaALxxk31nnaPZB9tzjwxFyPUBrwLuCXZ3FnAWg8VyV"
+{{cafes.remove.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{cafes.remove.js_http_client.code}}
 ```
 
 ??? success
@@ -2565,7 +2602,11 @@ The Textile API exposes a handful of the more useful IPFS endpoints. For the com
 At some point, you will want to view your IPFS peer ID. This is the same ID shown in your contact and profile info and printed by the daemon on startup:
 
 ```tab="cmd"
-textile ipfs id
+{{ipfs.peer_id.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{ipfs.peer_id.js_http_client.code}}
 ```
 
 ???+ success
@@ -2582,7 +2623,11 @@ Check out [this post](https://medium.com/textileio/how-ipfs-peer-nodes-identify-
 Your peer is always communicating, or "gossiping", with a changing sub-set of other peers on the IPFS network called a "swarm". You can view that swarm at any time. It should be relatively large at this point since your peer has been "online" for awhile.
 
 ```tab="cmd"
-textile ipfs swarm peers
+{{ipfs.swarm_peers.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{ipfs.swarm_peers.js_http_client.code}}
 ```
 
 ??? success
@@ -2858,7 +2903,11 @@ You may also want to check or open a connection to another peer. You can do this
 Try connecting to one of Textile's federated cafe peers:
 
 ```tab="cmd"
-textile ipfs swarm connect "/ip4/18.224.173.65/tcp/4001/ipfs/12D3KooWLh9Gd4C3knv4XqCyCuaNddfEoSLXgekVJzRyC5vsjv5d"
+{{ipfs.swarm_connect.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{ipfs.swarm_connect.js_http_client.code}}
 ```
 
 ???+ success
@@ -2875,7 +2924,11 @@ See the [IPFS doc](https://docs.ipfs.io/reference/api/cli/#ipfs-swarm-connect) f
 Downloading data behind a path is one of the most useful IPFS APIs. For example, we can "cat" an unencrypted Textile logo into a PNG file:
 
 ```tab="cmd"
-textile ipfs cat "QmarZwQEri4g2s8aw9CWKhxAzmg6rnLawGuSGYLSASEow6/0/d" > textile.png
+{{ipfs.cat.cmd.code}}
+```
+
+```JavaScript tab="JS HTTP"
+{{ipfs.cat.js_http_client.code}}
 ```
 
 ???+ success

--- a/snippets/a_tour_of_textile.yml
+++ b/snippets/a_tour_of_textile.yml
@@ -40,7 +40,9 @@ examples:
       cmd:
         code: 'textile threads add "My runs" --schema-file "~/Downloads/location.json" --type="public" --sharing="invite_only"'
       js_http_client:
-        code: 'await textile.threads.add("My runs", JSON.stringify(locations), undefined, "public", "invite_only")'
+        code: |
+              const locations = (await fetch("location.json")).json()
+              const thread = await textile.threads.add("My runs", locations, undefined, "public", "invite_only")
       react_native:
         code: '@todo'
       ios:
@@ -112,7 +114,7 @@ examples:
       cmd:
         code: 'textile feed --thread="12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw"'
       js_http_client:
-        code: 'await textile.feed.get("12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw")'
+        code: 'await textile.feed.list("12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw")'
       react_native:
         code: 'await textile.feed.list("12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw")'
       ios:
@@ -121,9 +123,9 @@ examples:
         code: '@todo'
     add_location_data:
       cmd:
-        code: "echo '{ \"latitude\": 48.858093, \"longitude\": 2.294694 }' | textile files add --thread=\"12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw\"'"
+        code: "echo '{ \"latitude\": 48.858093, \"longitude\": 2.294694 }' | textile files add --thread=12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw"
       js_http_client:
-        code: 'await textile.files.add(JSON.stringify({ \"latitude\": 48.858093, \"longitude\": 2.294694 }), "", "12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw")'
+        code: 'await textile.files.add({ latitude: 48.858093, longitude: 2.294694 }, "", "12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw")'
       react_native:
         code: |
               const input = Buffer.from(JSON.stringify({ "latitude": 48.858093, "longitude": 2.294694 }).toString('base64')
@@ -137,7 +139,7 @@ examples:
       cmd:
         code: "echo '{ \"latitude\": 91, \"longitude\": 2.294694 }' | textile files add --thread=\"12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw\"'"
       js_http_client:
-        code: 'await textile.files.add(JSON.stringify({ \"latitude\": 91, \"longitude\": 2.294694 }), "", "12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw")'
+        code: 'await textile.files.add({ latitude: 91, longitude: 2.294694 }, "", "12D3KooWBfdhD4tNMuTn5MHGof2bMZBKAUjFF3DBL3kuQQE5m1qw")'
       react_native:
         code: |
               const input = Buffer.from(JSON.stringify({ "latitude": 91, "longitude": 2.294694 }).toString('base64')

--- a/snippets/common.yml
+++ b/snippets/common.yml
@@ -2,7 +2,7 @@ core:
   setup:
     js_http_client:
       code: |
-            // no initialization needed, only import
+            // No initialization needed, only import
             import textile from "@textile/js-http-client"
     react_native:
       code: |
@@ -19,9 +19,13 @@ core:
   logs:
     cmd:
       code: 'textile logs'
+    js_http_client:
+      code: 'const levels = await textile.logs.get()'
   logs_text_only:
     cmd:
-      code: 'textile logs --tex-only --level="info"'
+      code: 'textile logs --level="info" --tex-only'
+    js_http_client:
+      code: 'const levels = await textile.logs.set("info", undefined, true)'
   init:
     cmd:
       code: 'textile init --seed="$(textile wallet init | tail -n1)" --repo-dir="/tmp/buddy" --swarm-ports="4101" --api-bind-addr="127.0.0.1:41600" --gateway-bind-addr="127.0.0.1:5150"'
@@ -40,7 +44,7 @@ core:
     cmd:
       code: 'textile summary'
     js_http_client:
-      code: '@todo'
+      code: 'const summary = await textile.utils.summary()'
     react_native:
       code: 'const summary = await textile.summary()'
     ios:
@@ -51,23 +55,46 @@ core:
     cmd:
       code: 'textile ping 12D3KooWLh9Gd4C3knv4XqCyCuaNddfEoSLXgekVJzRyC5vsjv5d'
     js_http_client:
-      code: '@todo'
+      code: 'await textile.utils.ping("12D3KooWLh9Gd4C3knv4XqCyCuaNddfEoSLXgekVJzRyC5vsjv5d")'
     react_native:
       code: '@todo'
     ios:
       code: '@todo'
     android:
       code: '@todo'
+  config:
+    cmd:
+      code: 'textile config "Addresses"'
+    js_http_client:
+      code: 'const config = await textile.config.get("Addresses")'
+  config_set:
+    cmd:
+      code: 'textile config "Addresses.Gateway" \"127.0.0.1:9090\"'
+    js_http_client:
+      code: 'const config = await textile.config.set("Addresses.Gateway", "127.0.0.1:9090")'
 subscribe:
   files:
     cmd:
       code: 'textile subscribe --type="files"'
     js_http_client:
       code: |
-            textile.subscribe.stream("files")
-              .then((file) => {
-                // new file!
-              })
+            // The js-http-client returns a `ReadableStream` to be accessed by the caller
+            // See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream for details
+            const stream = await textile.subscribe.stream("files")
+            const reader = stream.getReader()
+            const read = (result) => { // ReadableStreamReadResult<FeedItem>
+              if (result.done) {
+                return
+              }
+              try {
+                console.log(result.value)  
+              } catch (err) {
+                reader.cancel(undefined)
+                return
+              }
+              read(await reader.read())
+            }
+            read(await reader.read())
     react_native:
       code: |
             textile.events.addThreadUpdateReceivedListener((update) => {
@@ -108,7 +135,7 @@ profile:
     cmd:
       code: 'textile profile get'
     js_http_client:
-      code: await textile.profile.get()
+      code: 'const profile = await textile.profile.get()'
     react_native:
       code: 'const profile = await textile.profile.get()'
     ios:
@@ -144,7 +171,10 @@ profile:
     cmd:
       code: 'textile profile set avatar "path/to/an/image"'
     js_http_client:
-      code: 'await textile.profile.setAvatar("<image-hash>")'
+      code: |
+            const form = new FormData()
+            form.append('file', file, file.name) // file is File object or raw Buffer/Blob
+            await textile.profile.setAvatar(form)
     react_native:
       code: 'await textile.profile.setAvatar("<image-hash>")'
     ios:
@@ -156,7 +186,7 @@ account:
     cmd:
       code: 'textile account get'
     js_http_client:
-      code: 'await textile.account.get()'
+      code: 'const account = await textile.account.get()'
     react_native:
       code: |
             // React native has endpoints for each component of the account
@@ -169,7 +199,7 @@ account:
     cmd:
       code: 'textile account seed'
     js_http_client:
-      code: 'await textile.account.seed()'
+      code: 'const seed = await textile.account.seed()'
     react_native:
       code: 'const seed = await textile.account.seed()'
     ios:
@@ -193,7 +223,10 @@ contacts:
     cmd:
       code: 'textile contacts search --name="Andrew"'
     js_http_client:
-      code: 'await textile.contacts.search("Andrew")'
+      code: |
+            // The js-http-client returns a `ReadableStream` to be accessed by the caller
+            // See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream for details
+            const stream = await textile.contacts.search("Andrew")
     react_native:
       code: '@todo'
     ios:
@@ -205,7 +238,9 @@ contacts:
     cmd:
       code: 'textile contacts search --address="P8rW2RCMn75Dcb96Eiyg8mirb8nL4ruCumvJxKZRfAdpE5fG"'
     js_http_client:
-      code: 'await textile.contacts.search(undefined, "P8rW2RCMn75Dcb96Eiyg8mirb8nL4ruCumvJxKZRfAdpE5fG")'
+      code: |
+            // Again, `stream` is a `ReadableStream` to be accessed by the caller
+            const stream = await textile.contacts.search(undefined, "P8rW2RCMn75Dcb96Eiyg8mirb8nL4ruCumvJxKZRfAdpE5fG")
     react_native:
       code: '@todo'
     ios:
@@ -217,7 +252,9 @@ contacts:
     cmd:
       code: 'textile contacts add --address="P8rW2RCMn75Dcb96Eiyg8mirb8nL4ruCumvJxKZRfAdpE5fG"'
     js_http_client:
-      code: 'await textile.contacts.add("P8rW2RCMn75Dcb96Eiyg8mirb8nL4ruCumvJxKZRfAdpE5fG")'
+      code: |
+            const contact = ... // Should be a Contact object, as returned by `search` `ReadableStream`
+            await textile.contacts.add("P8rW2RCMn75Dcb96Eiyg8mirb8nL4ruCumvJxKZRfAdpE5fG", contact)
     react_native:
       code: '@todo'
     ios:
@@ -293,7 +330,9 @@ threads:
     cmd:
       code: 'textile threads add "Any old data" --blob'
     js_http_client:
-      code: 'await textile.threads.add("Any old data", "blob")'
+      code: |
+            const blob = (await textile.schemas.defaults()).blob
+            const thread = await textile.threads.add("Any old data", blob)
     react_native:
       code: '@todo'
     ios:
@@ -318,7 +357,7 @@ files:
     cmd:
       code: 'echo "mmm, bytes..." | textile files add --thread="12D3KooWSYT6SUL9fx15pwjHSVUsuymnbixmRtPGySmFYtWE51Sc"'
     js_http_client:
-      code: 'await textile.files.add("mmm, bytes...", "", "12D3KooWSYT6SUL9fx15pwjHSVUsuymnbixmRtPGySmFYtWE51Sc")'
+      code: 'const block = await textile.files.add("mmm, bytes...", "", "12D3KooWSYT6SUL9fx15pwjHSVUsuymnbixmRtPGySmFYtWE51Sc")'
     react_native:
       code: |
             const input = Buffer.from("mmm, bytes...").toString('base64')
@@ -333,7 +372,8 @@ files:
       code: 'textile files add "~/Downloads/william-milliot-510766-unsplash.jpg" --caption="Dog at work." --thread="12D3KooWNihfHDLsiJ36qQRQQ2vMcBZRHd2VBs3wTFtyGEk7zGeq"'
     js_http_client:
       code: |
-            const base64ImageString = "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABA...."
+            const form = new FormData()
+            form.append('file', file, file.name) // file is File object or raw Buffer/Blob or even fs.createReadStream() in Node.js
             await textile.files.add(base64ImageString, "Dog at work", "12D3KooWNihfHDLsiJ36qQRQQ2vMcBZRHd2VBs3wTFtyGEk7zGeq")'
     react_native:
       code: |
@@ -355,3 +395,57 @@ files:
       code: '@todo'
     android:
       code: '@todo'
+cafes:
+  tokens_create:
+    cmd:
+      code: 'textile tokens create'
+    js_http_client:
+      code: 'const token = await textile.tokens.create()'
+  tokens_list:
+    cmd:
+      code: 'textile tokens ls'
+    js_http_client:
+      code: 'const tokens = await textile.tokens.list()'
+  add:
+    cmd:
+      code: 'textile cafes add "http://127.0.0.1:40601" --token="bYJLFjHsRsZjdzEwC2pJwQthmfYb3DPYyBCcU49Dkfqd5xGHk5NR77X8GDKG"'
+    js_http_client:
+      code: |
+            const token = "bYJLFjHsRsZjdzEwC2pJwQthmfYb3DPYyBCcU49Dkfqd5xGHk5NR77X8GDKG"
+            const success = await textile.cafes.add("http://127.0.0.1:40601", token)
+  list:
+    cmd:
+      code: 'textile cafes ls'
+    js_http_client:
+      code: 'const sessions = await textile.cafes.list()'
+  messages:
+    cmd:
+      code: 'textile cafes messages'
+    js_http_client:
+      code: 'const success = await textile.cafes.messages()'
+  remove:
+    cmd:
+      code: 'textile cafes rm "12D3KooW9yaALxxk31nnaPZB9tzjwxFyPUBrwLuCXZ3FnAWg8VyV"'
+    js_http_client:
+      code: 'const success = await textile.cafes.remove("12D3KooW9yaALxxk31nnaPZB9tzjwxFyPUBrwLuCXZ3FnAWg8VyV")'
+ipfs:
+  peer_id:
+    cmd:
+      code: 'textile ipfs id'
+    js_http_client:
+      code: 'const id = await textile.ipfs.id()'
+  swarm_peers:
+    cmd:
+      code: 'textile ipfs swarm peers'
+    js_http_client:
+      code: 'const peers = await textile.ipfs.peers()'
+  swarm_connect:
+    cmd:
+      code: 'textile ipfs swarm connect "/ip4/18.224.173.65/tcp/4001/ipfs/12D3KooWLh9Gd4C3knv4XqCyCuaNddfEoSLXgekVJzRyC5vsjv5d"'
+    js_http_client:
+      code: 'const success = await textile.ipfs.connect("/ip4/18.224.173.65/tcp/4001/ipfs/12D3KooWLh9Gd4C3knv4XqCyCuaNddfEoSLXgekVJzRyC5vsjv5d")'
+  cat:
+    cmd:
+      code: 'textile ipfs cat "QmarZwQEri4g2s8aw9CWKhxAzmg6rnLawGuSGYLSASEow6/0/d" > textile.png'
+    js_http_client:
+      code: 'const logo = await textile.ipfs.cat("QmarZwQEri4g2s8aw9CWKhxAzmg6rnLawGuSGYLSASEow6/0/d")'


### PR DESCRIPTION
Fixes: #33. I think we now have parity with `cmd`wherever possible. There are probably a few points where the streaming API endpoints could be better outlined, but these are hard to 'show' in short snippets. Especially if we are trying to demo the similarities. I've added references where needed. I'll also create some gists with examples that we can link to I think.