### PR TITLE
adds 404 page back to statics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,8 @@ theme:
     code: Roboto Mono
   favicon: images/favicon.ico
   logo: images/logo_pink.svg
+  static_templates:
+    - 404.html
 
 extra_javascript:
   - js/sidebar.js


### PR DESCRIPTION
currently we are falling back to gh default 404 which isn't helpful because you can't easily navigate to a real docs page. updates to,

<img width="1374" alt="Screen Shot 2019-05-31 at 6 49 03 PM" src="https://user-images.githubusercontent.com/370259/58741969-cc92f800-83d4-11e9-98f3-be610ad72619.png">
