### PR TITLE
update bigsectors && explain boostrap from snapshot

### DIFF
--- a/docs/powergate/localnet.md
+++ b/docs/powergate/localnet.md
@@ -71,14 +71,11 @@ With whichever method you chose in the Installation section above, you can now u
 Docker files for the Powergate are all contained in the folder, `/docker`.
 
 ```bash
-BIGSECTORS=false make localnet
+make localnet
 ```
 
 !!!info
-    You can set `BIGSECTORS` according to your needs. See the description [above](#filecoin-localnet) for more information. If you don't specify a `BIGSECTORS` environment variable, the default is `false`.
-
-!!!Warning
-    Unfortunately, due to [a limitation](https://github.com/filecoin-project/lotus/issues/3109) in the latest Lotus setup `BIGSECTORS=true` isn't currently supported. Please give some thumbs up to help increase its priority!
+    You can set `BIGSECTORS` according to your needs. See the description [above](#filecoin-localnet) for more information. If you don't specify a `BIGSECTORS` environment variable, the default is `true`.
 
 If this is your first time running the Powergate, Docker will download the required instances before any Powergate setup begins. Downloads are dependent on your bandwidth and may take **a few minutes**, but wont be required for subsequent runs of the Powergate.
 

--- a/docs/powergate/testnet.md
+++ b/docs/powergate/testnet.md
@@ -54,7 +54,7 @@ Syncing a new Lotus node from genesis can take a considerable time. The current 
 Bootstraping the Lotus node from a snapshot implies complete trust in the party who generated the snapshot, so this is a pragmatic solution for getting up to speed fast. Depending on your use case you should consider the security risks of accepting snapshots from trusted parties.
 
 In order to boostrap from a snapshot in `testnet`, download the [snapshot CAR file](https://very-temporary-spacerace-chain-snapshot.s3-us-west-2.amazonaws.com/Spacerace_stateroots_snapshot_latest.car). This file is mantained up to date by Protocol Labs.
-We're going to assume this CAR file was downloaded to your local path: `/home/myuser/Spacerace_stateroots_snapshot_latest.car`.
+We're going to assume this CAR file was downloaded to your local path: `/home/myuser/snapshots/Spacerace_stateroots_snapshot_latest.car`.
 
 You should edit the `docker/docker-compose.yaml` file adding two lines:
 ![image](https://user-images.githubusercontent.com/6136245/93375329-6383fd80-f82e-11ea-9850-2970f30a793c.png)

--- a/docs/powergate/testnet.md
+++ b/docs/powergate/testnet.md
@@ -48,6 +48,22 @@ mined block in the past	{"block-time": "2009-01-01T04:44:30.000Z",\
 
 When complete, you will have a fully functional Powergate (`powd`), a Lotus node, and an IPFS node wired correctly together to start using the Testnet!
 
+### Bootstrap from a snapshot
+
+Syncing a new Lotus node from genesis can take a considerable time. The current `testnet` network is providing snapshots of the VM state every 6hrs, which means, in the worst case, syncing 6hs of new blocks.
+Bootstraping the Lotus node from a snapshot implies complete trust in the party who generated the snapshot, so this is a pragmatic solution for getting up to speed fast. Depending on your use case you should consider the security risks of accepting snapshots from trusted parties.
+
+In order to boostrap from a snapshot in `testnet`, download the [snapshot CAR file](https://very-temporary-spacerace-chain-snapshot.s3-us-west-2.amazonaws.com/Spacerace_stateroots_snapshot_latest.car). This file is mantained up to date by Protocol Labs.
+We're going to assume this CAR file was downloaded to your local path: `/home/myuser/Spacerace_stateroots_snapshot_latest.car`.
+
+You should edit the `docker/docker-compose.yaml` file adding two lines:
+![image](https://user-images.githubusercontent.com/6136245/93375329-6383fd80-f82e-11ea-9850-2970f30a793c.png)
+
+Then run `make up`. If you inspect the Lotus node with `docker logs testnet_lotus_1`, you will see a message that is importing chain information, and a bunch of Badger compaction messages. After the importing is done, the Lotus node will continue to sync as usual showing the typical logs. At this point you should `make down` (you don't need to wait to full syncing), revert `docker/docker-compose.yaml` to the original content, and `make up` again.
+
+Congratulations! You're now syncing from a trusted checkpoint.
+
+
 ### Create a deal and store a file
 
 Now that your Powergate is running on testnet, all the CLI and API commands are the same as if you had run it on localnet before.

--- a/docs/powergate/testnet.md
+++ b/docs/powergate/testnet.md
@@ -53,7 +53,7 @@ When complete, you will have a fully functional Powergate (`powd`), a Lotus node
 Syncing a new Lotus node from genesis can take a considerable time. The current `testnet` network is providing snapshots of the VM state every 6hrs, which means, in the worst case, syncing 6hs of new blocks.
 Bootstraping the Lotus node from a snapshot implies complete trust in the party who generated the snapshot, so this is a pragmatic solution for getting up to speed fast. Depending on your use case you should consider the security risks of accepting snapshots from trusted parties.
 
-In order to boostrap from a snapshot in `testnet`, download the [snapshot CAR file](https://very-temporary-spacerace-chain-snapshot.s3-us-west-2.amazonaws.com/Spacerace_stateroots_snapshot_latest.car). This file is mantained up to date by Protocol Labs.
+In order to boostrap from a snapshot in `testnet`, download the [snapshot CAR file](https://very-temporary-spacerace-chain-snapshot.s3-us-west-2.amazonaws.com/Spacerace_stateroots_snapshot_latest.car). This file is maintained up to date by Protocol Labs.
 We're going to assume this CAR file was downloaded to your local path: `/home/myuser/snapshots/Spacerace_stateroots_snapshot_latest.car`.
 
 You should edit the `docker/docker-compose.yaml` file adding two lines:


### PR DESCRIPTION
We had some stalled docs reg the bigsectors problem.

Also adds some rough explanation of how to `make up` from a snapshot. Docker makes this a bit cumbersome, but tbh is just changing two lines. Automating this in a command requires some thought for reasons I could explain.

That's good enough for now.
