### PR TITLE
Fix broken link to hub cli docs

### DIFF
--- a/docs/hub/apis.md
+++ b/docs/hub/apis.md
@@ -90,12 +90,12 @@ _[See CLI commands](../hub/cli/hub_keys.md)_
 You can find all remote Thread and Bucket APIs in the `textile` libraries below. These libraries are meant to work in combination with the `threads` libraries when you want to create and manage Threads database in your app. 
 
 <div class="txtl-options">
-  <a href="https://textileio.github.io/js-hub/docs/" target="_blank class="box">
+  <a href="https://textileio.github.io/js-hub/docs/" target="_blank" class="box">
     <h5>JS Hub</h5>
     <p>Start threads, buckets, and user creation in any JavaScript app.</p>
   </a>
   <span class="box-space"> </span>
-  <a href="https://godoc.org/github.com/textileio/textile/api/buckets" target="_blank class="box">
+  <a href="https://godoc.org/github.com/textileio/textile/api/buckets" target="_blank" class="box">
     <h5>JS Hub</h5>
     <p>Use the Buckets client from Go</p>
   </a>

--- a/docs/hub/apis.md
+++ b/docs/hub/apis.md
@@ -100,7 +100,7 @@ You can find all remote Thread and Bucket APIs in the `textile` libraries below.
     <p>Use the Buckets client from Go</p>
   </a>
   <span class="box-space"> </span>
-  <a href="../hub/cli/hub" class="box">
+  <a href="../cli/hub" class="box">
     <h5>Hub CLI</h5>
     <p>Use scripting and command-line tooling with the Hub CLI.</p>
   </a>


### PR DESCRIPTION
![Screenshot 2020-09-17 at 15 51 22](https://user-images.githubusercontent.com/1060/93487930-ae207b00-f8fd-11ea-9cec-7aa49bf1747a.png)

The link to the CLI docs here at the bottom of this page (https://docs.textile.io/hub/apis/#api-libraries) goes to `https://docs.textile.io/hub/hub/cli/hub` which 404s, I believe this fixes it.