### PR TITLE
change CAR file link to pruned version

### DIFF
--- a/docs/powergate/testnet.md
+++ b/docs/powergate/testnet.md
@@ -53,8 +53,8 @@ When complete, you will have a fully functional Powergate (`powd`), a Lotus node
 Syncing a new Lotus node from genesis can take a considerable time. The current `testnet` network is providing snapshots of the VM state every 6hrs, which means, in the worst case, syncing 6hs of new blocks.
 Bootstraping the Lotus node from a snapshot implies complete trust in the party who generated the snapshot, so this is a pragmatic solution for getting up to speed fast. Depending on your use case you should consider the security risks of accepting snapshots from trusted parties.
 
-In order to boostrap from a snapshot in `testnet`, download the [snapshot CAR file](https://very-temporary-spacerace-chain-snapshot.s3-us-west-2.amazonaws.com/Spacerace_stateroots_snapshot_latest.car). This file is maintained up to date by Protocol Labs.
-We're going to assume this CAR file was downloaded to your local path: `/home/myuser/snapshots/Spacerace_stateroots_snapshot_latest.car`.
+In order to boostrap from a snapshot in `testnet`, download the [snapshot CAR file](https://very-temporary-spacerace-chain-snapshot.s3.amazonaws.com/Spacerace_pruned_stateroots_snapshot_latest.car). This file is maintained up to date by Protocol Labs.
+We're going to assume this CAR file was downloaded to your local path: `/home/myuser/snapshots/Spacerace_pruned_stateroots_snapshot_latest.car`.
 
 You should edit the `docker/docker-compose.yaml` file adding two lines:
 ![image](https://user-images.githubusercontent.com/6136245/93375329-6383fd80-f82e-11ea-9850-2970f30a793c.png)


### PR DESCRIPTION
Change CAR snsapshot link to a pruned version which should be smaller than full snapshot.